### PR TITLE
Fix hydration of history entities

### DIFF
--- a/src/PersistenceLayer/History/HistoryEntity.php
+++ b/src/PersistenceLayer/History/HistoryEntity.php
@@ -11,12 +11,12 @@ final class HistoryEntity extends Entity
 {
     use EntityIdTrait;
 
-    private string $salesChannelId;
-    private string $languageId;
-    private string $entityName;
-    private string $entityId;
-    private array $data;
-    private \DateTimeInterface $sentAt;
+    protected string $salesChannelId;
+    protected string $languageId;
+    protected string $entityName;
+    protected string $entityId;
+    protected array $data;
+    protected \DateTimeInterface $sentAt;
 
     public function getSalesChannelId(): string
     {


### PR DESCRIPTION
Private fields in entities are not visible in hydration, so data is not getting loaded correctly. This leads to an error in history manager in method "getLastSentData": "Typed property Makaira\Connect\PersistenceLayer\History\HistoryEntity::$data must not be accessed before initialization".