### PR TITLE
fix: Load products by category

### DIFF
--- a/src/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
+++ b/src/Core/Content/Product/SalesChannel/Listing/ProductListingRoute.php
@@ -83,7 +83,7 @@ class ProductListingRoute extends AbstractProductListingRoute
         try {
             $makairaSorting = $this->sortingMappingService->mapSortingCriteria($criteria);
 
-            $makairaResponse = $this->makairaProductFetchingService->fetchMakairaProductsFromCategory($context, $catId, $criteria, $makairaFilter, $makairaSorting);
+            $makairaResponse = $this->makairaProductFetchingService->fetchMakairaProductsFromCategory($context, $categoryId, $criteria, $makairaFilter, $makairaSorting);
 
             if (!$makairaResponse instanceof stdClass) {
                 throw new NoDataException('Keine Daten oder fehlerhaft vom Makaira Server.');


### PR DESCRIPTION
The variable `$catId`, which is used while loading products by category, is not defined. I guess `$categoryId` is meant, but did not find any documentation on the constraint "query.category_id", so I don't know which value is expected. Please check if this is correct.